### PR TITLE
Add bottom padding after contact line

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,13 @@
 <body>
   <div class="container">
     <div class="text-block">
-      <p>ultraver.se</p>
+      <p><strong>ultraver.se</strong></p>
       <p>The frontier of human potential.</p>
       <p>We build tools for the next 100 years.</p>
       <p>&nbsp;</p>
       <p>Contact us at</p>
       <p>&gt; contact@ultraver.se</p>
+      <p>&nbsp;</p>
     </div>
     <canvas id="ascii-art"></canvas>
   </div>

--- a/script.js
+++ b/script.js
@@ -2,8 +2,13 @@ const canvas = document.getElementById('ascii-art');
 const ctx = canvas.getContext('2d');
 
 function resizeCanvas() {
-  canvas.width = window.innerWidth * 0.6;
-  canvas.height = window.innerHeight;
+  if (window.innerWidth <= 600) {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight * 0.5;
+  } else {
+    canvas.width = window.innerWidth * 0.6;
+    canvas.height = window.innerHeight;
+  }
 }
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);

--- a/style.css
+++ b/style.css
@@ -31,3 +31,26 @@ body {
   height: 100%;
   width: 100%;
 }
+
+@media (max-width: 600px) {
+  body {
+    overflow: hidden;
+  }
+
+  .container {
+    flex-direction: column;
+    height: 100vh;
+  }
+
+  .text-block {
+    width: 100%;
+    padding: 2rem;
+    font-size: 1rem;
+    height: 50vh;
+  }
+
+  #ascii-art {
+    width: 100%;
+    height: 50vh;
+  }
+}


### PR DESCRIPTION
## Summary
- add an empty paragraph under the contact email for spacing
- keep the body overflow hidden so no scrolling occurs on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686acca622d8832994fcc545f3865357