### PR TITLE
Fix mobile overlap issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,8 @@ const ctx = canvas.getContext('2d');
 function resizeCanvas() {
   if (window.innerWidth <= 600) {
     canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight * 0.5;
+    const textHeight = document.querySelector('.text-block').offsetHeight;
+    canvas.height = window.innerHeight - textHeight;
   } else {
     canvas.width = window.innerWidth * 0.6;
     canvas.height = window.innerHeight;

--- a/style.css
+++ b/style.css
@@ -46,11 +46,11 @@ body {
     width: 100%;
     padding: 2rem;
     font-size: 1rem;
-    height: 50vh;
+    height: auto;
   }
 
   #ascii-art {
     width: 100%;
-    height: 50vh;
+    flex: 1;
   }
 }


### PR DESCRIPTION
## Summary
- let text fill its natural height on mobile
- allow canvas to take remaining space
- resize canvas based on text block height

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ad33945088329a41bfcc252bce80d